### PR TITLE
feat: optional Module.preview() method [#27]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Promise. Exceptions (sync throw or async reject) are treated as advisory
   warnings via a `module_preview` check entry and do **not** fail validation
   — mirrors `preflight()` semantics (RFC Open Question 1).
+- **`TChange` schema upgraded to `Type.Unsafe<Change>` form** with raw JSON
+  Schema `patternProperties: { "^x-": {} }` + `additionalProperties: false`
+  in line with the upstream apcore RFC iter-11 cross-SDK schema-encoding
+  table (apcore commit
+  [`81df336`](https://github.com/aiperceivable/apcore/commit/81df336)). A
+  custom `apcore:Change` TypeBox kind is registered so `Value.Check(TChange,
+  ...)` accepts arbitrary `x-*` extension keys and rejects unknown non-`x-`
+  additional keys, closing the runtime-validation gap left by the previous
+  `Type.Object` form. Conformance test added: a `Change` with `x-foo` /
+  `x-count` round-trips through `Executor.validate()` and passes
+  `Value.Check`, while a `Change` with a plain `random_key` fails.
 
 > **Note:** This is a **speculative implementation** ahead of formal upstream
 > RFC acceptance. The RFC at `apcore/docs/spec/rfc-preview-method.md` is in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,37 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [Unreleased]
+
+### Added
+
+#### Module.preview() — speculative ahead of upstream RFC (Issue #27)
+
+- **Optional `Module.preview(inputs, ctx)` method** returning a structured
+  `PreviewResult | null | Promise<PreviewResult | null>`. Modules implement
+  this to self-report what side-effects executing the call would produce.
+  Detection mirrors `preflight()` / `stream()` (`typeof module.preview ===
+  'function'`).
+- **`PreviewResult` and `Change` types** — `Change` requires `action`,
+  `target`, `summary` (free-form strings); `before` / `after` are optional
+  `unknown` snapshots. `x-*` extension fields are permitted on `Change` records.
+- **`TPreviewResult` and `TChange` TypeBox schemas** exported alongside the
+  types for runtime validation / wire-format use.
+- **`PreflightResult.predictedChanges?: Change[]`** — populated by
+  `Executor.validate()` when the resolved module implements `preview()` and it
+  returns a non-null `PreviewResult`. Existing consumers reading `.valid`,
+  `.checks`, `.requiresApproval`, `.errors` are unaffected.
+- **`Executor.validate()` integration** — invokes `module.preview()` after the
+  standard validation pipeline succeeds, awaiting the result if it's a
+  Promise. Exceptions (sync throw or async reject) are treated as advisory
+  warnings via a `module_preview` check entry and do **not** fail validation
+  — mirrors `preflight()` semantics (RFC Open Question 1).
+
+> **Note:** This is a **speculative implementation** ahead of formal upstream
+> RFC acceptance. The RFC at `apcore/docs/spec/rfc-preview-method.md` is in
+> `Draft / RFC` status; field names and semantics may shift before the RFC
+> is accepted into PROTOCOL_SPEC.
+
 ## [0.20.0] - 2026-05-05
 
 ### Added

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -28,7 +28,14 @@ import {
   RetrySignal,
 } from './middleware/index.js';
 import { MiddlewareChainError, MiddlewareManager } from './middleware/manager.js';
-import type { Module, ModuleAnnotations, PreflightCheckResult, PreflightResult } from './module.js';
+import type {
+  Change,
+  Module,
+  ModuleAnnotations,
+  PreflightCheckResult,
+  PreflightResult,
+  PreviewResult,
+} from './module.js';
 import { createPreflightResult } from './module.js';
 import type { PipelineContext, PipelineTrace, StrategyInfo } from './pipeline.js';
 import {
@@ -759,7 +766,45 @@ export class Executor {
       }
     }
 
-    return createPreflightResult(checks, requiresApproval);
+    // Module-level preview() (optional, RFC `rfc-preview-method.md` — Draft / RFC).
+    // Invoked only after the standard validation pipeline has been processed.
+    // Returning null is equivalent to omitting the method. Exceptions (sync
+    // throws or async rejections) are treated as advisory warnings and do NOT
+    // fail validation, mirroring `preflight()` semantics (RFC Open Question 1).
+    let predictedChanges: Change[] | undefined;
+    if (pipeCtx.module != null) {
+      const mod = pipeCtx.module as Record<string, unknown>;
+      const modWithPreview = mod as { preview?: Module['preview'] };
+      if (typeof modWithPreview.preview === 'function') {
+        try {
+          const raw = modWithPreview.preview(effectiveInputs, pipeCtx.context);
+          // Support both sync and async preview() implementations.
+          const result: PreviewResult | null =
+            raw != null && typeof (raw as Promise<unknown>).then === 'function'
+              ? await (raw as Promise<PreviewResult | null>)
+              : (raw as PreviewResult | null);
+          if (result != null && Array.isArray(result.changes) && result.changes.length > 0) {
+            predictedChanges = result.changes;
+            checks.push({ check: 'module_preview', passed: true });
+          } else {
+            // Method present but returned null / empty — record the no-op
+            // check so consumers can distinguish "module has preview()" from
+            // "module does not implement preview()" if desired.
+            checks.push({ check: 'module_preview', passed: true });
+          }
+        } catch (exc: unknown) {
+          const excName = exc instanceof Error ? exc.constructor.name : 'Error';
+          const excMsg = exc instanceof Error ? exc.message : String(exc);
+          checks.push({
+            check: 'module_preview',
+            passed: true,
+            warnings: [`preview() raised ${excName}: ${excMsg}`],
+          });
+        }
+      }
+    }
+
+    return createPreflightResult(checks, requiresApproval, predictedChanges);
   }
 
   /** Map pipeline step names to PreflightResult check names. */

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,6 +54,8 @@ export {
   annotationsToJSON,
   annotationsFromJSON,
   createPreflightResult,
+  TChange,
+  TPreviewResult,
 } from './module.js';
 export type {
   ModuleAnnotations,
@@ -63,6 +65,8 @@ export type {
   PreflightCheckResult,
   PreflightResult,
   Module,
+  Change,
+  PreviewResult,
 } from './module.js';
 
 // Config

--- a/src/module.ts
+++ b/src/module.ts
@@ -2,7 +2,7 @@
  * Module interface and related data types.
  */
 
-import type { TSchema } from '@sinclair/typebox';
+import { type TSchema, Type } from '@sinclair/typebox';
 import type { Context } from './context.js';
 
 export interface ModuleAnnotations {
@@ -151,18 +151,117 @@ export interface PreflightResult {
   readonly checks: PreflightCheckResult[];
   readonly requiresApproval: boolean;
   readonly errors: Array<Record<string, unknown>>;
+  /**
+   * Optional. Module-self-reported structured prediction of the changes that
+   * executing the call would produce, populated by `Executor.validate()` when
+   * the target module implements `preview()` (see RFC
+   * `apcore/docs/spec/rfc-preview-method.md`, currently Draft / RFC).
+   *
+   * - Absent (or empty) when the module does not implement `preview()` or
+   *   when `preview()` returned `null`.
+   * - When `preview()` throws, `predictedChanges` is left unset and a
+   *   `module_preview` advisory check carries the warning, mirroring
+   *   `preflight()` semantics (warnings do not fail validation).
+   */
+  readonly predictedChanges?: Change[];
 }
 
 export function createPreflightResult(
   checks: PreflightCheckResult[],
   requiresApproval: boolean = false,
+  predictedChanges?: Change[],
 ): PreflightResult {
   const valid = checks.every(c => c.passed);
   const errors = checks
     .filter(c => !c.passed && c.error != null)
     .map(c => c.error!);
+  if (predictedChanges !== undefined) {
+    return { valid, checks, requiresApproval, errors, predictedChanges };
+  }
   return { valid, checks, requiresApproval, errors };
 }
+
+/**
+ * Structured prediction of a single side-effect that executing a module call
+ * would produce. Per RFC `apcore/docs/spec/rfc-preview-method.md`
+ * (Draft / RFC, target acceptance v0.21.0).
+ *
+ * `action`, `target`, and `summary` are required; module authors define their
+ * own free-form taxonomy for `action` (e.g. "write", "delete", "send",
+ * "charge", "publish") and `target` (e.g. "users.42", "smtp:user@example.com").
+ *
+ * `before` / `after` are optional snapshots of prior / predicted state. Both
+ * are typed `unknown` to keep the schema heterogeneous across module classes
+ * (DB writes, network calls, file I/O, email sends).
+ *
+ * Extension fields with the `x-` prefix are permitted (consistent with
+ * PROTOCOL_SPEC §4.4 extras).
+ */
+export interface Change {
+  /** Free-form verb describing the kind of change (e.g. "write", "delete", "send"). */
+  action: string;
+  /** Free-form identifier of what is changed (e.g. "users.42", "stripe:charge:ch_abc"). */
+  target: string;
+  /** Required, human-readable single-line summary of the change. */
+  summary: string;
+  /** Optional. Snapshot of the prior state, when observable. */
+  before?: unknown;
+  /** Optional. Predicted new state. */
+  after?: unknown;
+  /** Extension fields. Keys MUST start with the `x-` prefix. */
+  [key: `x-${string}`]: unknown;
+}
+
+/**
+ * Module's structured prediction of the changes that calling `execute()` with
+ * the given inputs would produce. Returned by the optional `Module.preview()`
+ * method; folded into `PreflightResult.predictedChanges` by
+ * `Executor.validate()`.
+ */
+export interface PreviewResult {
+  /** Ordered list of predicted side-effects. */
+  changes: Change[];
+}
+
+/**
+ * TypeBox schema mirroring `Change`. Exported alongside the TypeScript type
+ * for runtime validation / wire-format use. Mirrors the JSON Schema sketch in
+ * `apcore/docs/spec/rfc-preview-method.md`.
+ *
+ * `before` / `after` are typed as `Type.Unknown()` (free-form per module class
+ * per the RFC). The interface-level `x-*` extension fields are not encoded at
+ * the TypeBox level — JSON Schema's `patternProperties` is the tool for that
+ * if/when the RFC tightens to a closed schema.
+ */
+export const TChange = Type.Object({
+  action: Type.String({
+    description: 'Free-form verb describing the kind of change.',
+  }),
+  target: Type.String({
+    description: 'Free-form identifier of what is changed.',
+  }),
+  summary: Type.String({
+    description: 'Required, human-readable single-line summary of the change.',
+  }),
+  before: Type.Optional(
+    Type.Unknown({
+      description: 'Optional. Snapshot of the prior state, when observable.',
+    }),
+  ),
+  after: Type.Optional(
+    Type.Unknown({
+      description: 'Optional. Predicted new state.',
+    }),
+  ),
+});
+
+/** TypeBox schema mirroring `PreviewResult`. */
+export const TPreviewResult = Type.Object({
+  changes: Type.Array(TChange, {
+    description:
+      "Module's prediction of what would change if the call were executed.",
+  }),
+});
 
 export interface Module {
   inputSchema: TSchema;
@@ -175,6 +274,22 @@ export interface Module {
   validate?(inputs: Record<string, unknown>): ValidationResult | Promise<ValidationResult>;
   /** Optional: Domain-specific pre-execution warnings (called by Executor.validate() Check 7). Advisory only — warnings do NOT block execution. */
   preflight?(inputs: Record<string, unknown>, context: Context): string[] | Promise<string[]>;
+  /**
+   * Optional: Return a structured prediction of the changes this call would
+   * produce. Invoked by `Executor.validate()` after the standard validation
+   * pipeline succeeds, only on modules that implement it.
+   *
+   * Per RFC `apcore/docs/spec/rfc-preview-method.md` (currently Draft / RFC):
+   * - MUST NOT have side effects.
+   * - Returning `null` (or omitting the method) means "no predicted changes".
+   * - Throwing / rejecting is treated as advisory and does NOT fail validation.
+   *   The error is surfaced as a warning via the `module_preview` check,
+   *   matching `preflight()` semantics.
+   */
+  preview?(
+    inputs: Record<string, unknown>,
+    context: Context,
+  ): PreviewResult | null | Promise<PreviewResult | null>;
   /** Optional: Return module description for LLM/AI tool discovery. */
   describe?(): ModuleDescription | Promise<ModuleDescription>;
   /** Optional: Called when module is loaded into the registry. */

--- a/src/module.ts
+++ b/src/module.ts
@@ -2,7 +2,7 @@
  * Module interface and related data types.
  */
 
-import { type TSchema, Type } from '@sinclair/typebox';
+import { Kind, type TSchema, Type, TypeRegistry } from '@sinclair/typebox';
 import type { Context } from './context.js';
 
 export interface ModuleAnnotations {
@@ -224,35 +224,83 @@ export interface PreviewResult {
 }
 
 /**
+ * Custom TypeBox kind for `Change`.
+ *
+ * Encoded via `Type.Unsafe<Change>(...)` so the underlying JSON Schema can
+ * carry both `patternProperties: { "^x-": {} }` (admitting arbitrary `x-*`
+ * extension keys per PROTOCOL_SPEC §4.4 / §4.6 conventions) and
+ * `additionalProperties: false` (rejecting unknown non-`x-` keys). TypeBox
+ * 0.34's `Type.Object` schema-checker does not consult `patternProperties`,
+ * so a `Type.Object({...}, { additionalProperties: false })` form would
+ * incorrectly reject `x-*` keys; and `Type.Intersect([Object, Record])`
+ * loses `additionalProperties: false` precision. The cross-SDK
+ * schema-encoding table in `apcore/docs/spec/rfc-preview-method.md`
+ * ("Change.x-* extension fields") prescribes the `Type.Unsafe` escape hatch.
+ *
+ * To make the schema usable with `Value.Check` (which routes by `[Kind]`), we
+ * register a custom `'apcore:Change'` kind whose checker enforces the same
+ * shape the JSON Schema describes. The JSON Schema body remains the canonical
+ * cross-SDK wire form.
+ */
+const CHANGE_KIND = 'apcore:Change';
+
+if (!TypeRegistry.Has(CHANGE_KIND)) {
+  TypeRegistry.Set(CHANGE_KIND, (_schema, value): boolean => {
+    if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+      return false;
+    }
+    const v = value as Record<string, unknown>;
+    if (typeof v.action !== 'string') return false;
+    if (typeof v.target !== 'string') return false;
+    if (typeof v.summary !== 'string') return false;
+    const known = new Set(['action', 'target', 'summary', 'before', 'after']);
+    for (const key of Object.keys(v)) {
+      if (known.has(key)) continue;
+      // Anything else MUST start with `x-` (any value).
+      if (!key.startsWith('x-')) return false;
+    }
+    return true;
+  });
+}
+
+/**
  * TypeBox schema mirroring `Change`. Exported alongside the TypeScript type
  * for runtime validation / wire-format use. Mirrors the JSON Schema sketch in
- * `apcore/docs/spec/rfc-preview-method.md`.
- *
- * `before` / `after` are typed as `Type.Unknown()` (free-form per module class
- * per the RFC). The interface-level `x-*` extension fields are not encoded at
- * the TypeBox level — JSON Schema's `patternProperties` is the tool for that
- * if/when the RFC tightens to a closed schema.
+ * `apcore/docs/spec/rfc-preview-method.md`. The raw JSON Schema body
+ * (`type`, `required`, `properties`, `patternProperties`,
+ * `additionalProperties: false`) is the canonical cross-SDK wire format; the
+ * `[Kind]` field routes `Value.Check` to the registered checker above.
  */
-export const TChange = Type.Object({
-  action: Type.String({
-    description: 'Free-form verb describing the kind of change.',
-  }),
-  target: Type.String({
-    description: 'Free-form identifier of what is changed.',
-  }),
-  summary: Type.String({
-    description: 'Required, human-readable single-line summary of the change.',
-  }),
-  before: Type.Optional(
-    Type.Unknown({
+export const TChange = Type.Unsafe<Change>({
+  [Kind]: CHANGE_KIND,
+  type: 'object',
+  required: ['action', 'target', 'summary'],
+  properties: {
+    action: {
+      type: 'string',
+      description: 'Free-form verb describing the kind of change.',
+    },
+    target: {
+      type: 'string',
+      description: 'Free-form identifier of what is changed.',
+    },
+    summary: {
+      type: 'string',
+      description: 'Required, human-readable single-line summary of the change.',
+    },
+    before: {
+      // unknown — module-class specific. JSON Schema `{}` accepts any value.
       description: 'Optional. Snapshot of the prior state, when observable.',
-    }),
-  ),
-  after: Type.Optional(
-    Type.Unknown({
+    },
+    after: {
       description: 'Optional. Predicted new state.',
-    }),
-  ),
+    },
+  },
+  patternProperties: {
+    // Arbitrary x-* extension keys with arbitrary values (PROTOCOL_SPEC §4.4).
+    '^x-': {},
+  },
+  additionalProperties: false,
 });
 
 /** TypeBox schema mirroring `PreviewResult`. */

--- a/tests/test-module-preview.test.ts
+++ b/tests/test-module-preview.test.ts
@@ -10,9 +10,11 @@
 
 import { describe, it, expect } from 'vitest';
 import { Type } from '@sinclair/typebox';
+import { Value } from '@sinclair/typebox/value';
 import { Executor } from '../src/executor.js';
 import { FunctionModule } from '../src/decorator.js';
 import { Registry } from '../src/registry/registry.js';
+import { TChange } from '../src/module.js';
 import type {
   Change,
   Module,
@@ -228,5 +230,59 @@ describe('Module.preview() / PreflightResult.predictedChanges', () => {
     const changes = result.predictedChanges as Change[];
     expect(changes).toHaveLength(1);
     expect(changes[0]!['x-confidence']).toBe(0.95);
+  });
+
+  it('preserves Change.x-* extension fields end-to-end and validates against TChange', async () => {
+    // Per upstream RFC `apcore/docs/spec/rfc-preview-method.md` ("Change.x-*
+    // extension fields — cross-SDK schema-encoding note"), TChange uses
+    // `patternProperties: { "^x-": {} }` + `additionalProperties: false`.
+    // This test is the litmus check: x-* keys round-trip through
+    // Executor.validate(), Value.Check(TChange, ...) accepts them, and
+    // unknown non-x- keys are rejected.
+    const mod: Module = {
+      inputSchema,
+      outputSchema,
+      description: 'Preview with x-* extension round-trip',
+      execute: () => ({ ok: true }),
+      preview: (): PreviewResult => ({
+        changes: [
+          {
+            action: 'write',
+            target: 'x',
+            summary: 's',
+            'x-foo': 'bar',
+            'x-count': 42,
+          },
+        ],
+      }),
+    };
+    const executor = buildExecutor('preview.xroundtrip', mod);
+    const result = await executor.validate('preview.xroundtrip', { id: 'x' });
+
+    // 1. End-to-end: x-* keys survive through Executor.validate().
+    expect(result.valid).toBe(true);
+    const changes = result.predictedChanges as Change[];
+    expect(changes).toHaveLength(1);
+    const change = changes[0]!;
+    expect(change['x-foo']).toBe('bar');
+    expect(change['x-count']).toBe(42);
+
+    // 2. Schema validation: TChange admits arbitrary x-* keys.
+    expect(Value.Check(TChange, change)).toBe(true);
+
+    // 3. Schema validation: a Change with only required fields still passes.
+    expect(
+      Value.Check(TChange, { action: 'a', target: 't', summary: 's' }),
+    ).toBe(true);
+
+    // 4. Regression for additionalProperties: false — unknown non-x- keys
+    //    must be rejected by TChange.
+    const bogus = {
+      action: 'a',
+      target: 't',
+      summary: 's',
+      random_key: 'no',
+    };
+    expect(Value.Check(TChange, bogus)).toBe(false);
   });
 });

--- a/tests/test-module-preview.test.ts
+++ b/tests/test-module-preview.test.ts
@@ -1,0 +1,232 @@
+/**
+ * Tests for the optional `Module.preview()` method and
+ * `PreflightResult.predictedChanges` field.
+ *
+ * Speculative implementation tracking the upstream apcore RFC at
+ * `apcore/docs/spec/rfc-preview-method.md` (currently `Draft / RFC`).
+ *
+ * Cross-references issue aiperceivable/apcore-typescript#27.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { Type } from '@sinclair/typebox';
+import { Executor } from '../src/executor.js';
+import { FunctionModule } from '../src/decorator.js';
+import { Registry } from '../src/registry/registry.js';
+import type {
+  Change,
+  Module,
+  PreflightCheckResult,
+  PreviewResult,
+} from '../src/module.js';
+
+const inputSchema = Type.Object({ id: Type.String() });
+const outputSchema = Type.Object({ ok: Type.Boolean() });
+
+function buildExecutor(moduleId: string, mod: Module): Executor {
+  const registry = new Registry();
+  registry.register(moduleId, mod);
+  return new Executor({ registry });
+}
+
+describe('Module.preview() / PreflightResult.predictedChanges', () => {
+  it('module without preview() leaves predictedChanges absent', async () => {
+    const mod = new FunctionModule({
+      execute: () => ({ ok: true }),
+      moduleId: 'no.preview',
+      inputSchema,
+      outputSchema,
+      description: 'No preview method',
+    });
+    const executor = buildExecutor('no.preview', mod);
+    const result = await executor.validate('no.preview', { id: 'x' });
+
+    expect(result.valid).toBe(true);
+    expect(result.predictedChanges).toBeUndefined();
+    expect(
+      result.checks.some((c: PreflightCheckResult) => c.check === 'module_preview'),
+    ).toBe(false);
+  });
+
+  it('preview() returning null leaves predictedChanges absent', async () => {
+    const mod: Module = {
+      inputSchema,
+      outputSchema,
+      description: 'Preview returns null',
+      execute: () => ({ ok: true }),
+      preview: (): PreviewResult | null => null,
+    };
+    const executor = buildExecutor('preview.null', mod);
+    const result = await executor.validate('preview.null', { id: 'x' });
+
+    expect(result.valid).toBe(true);
+    expect(result.predictedChanges).toBeUndefined();
+    // The check is recorded (method was present and returned cleanly), even
+    // though no changes were produced.
+    expect(
+      result.checks.some(
+        (c: PreflightCheckResult) => c.check === 'module_preview' && c.passed,
+      ),
+    ).toBe(true);
+  });
+
+  it('preview() returning a single Change with required fields populates predictedChanges', async () => {
+    const mod: Module = {
+      inputSchema,
+      outputSchema,
+      description: 'Preview single change',
+      execute: () => ({ ok: true }),
+      preview: (inputs): PreviewResult => ({
+        changes: [
+          {
+            action: 'send',
+            target: `smtp:user-${inputs['id'] as string}`,
+            summary: 'Send confirmation email',
+          },
+        ],
+      }),
+    };
+    const executor = buildExecutor('preview.one', mod);
+    const result = await executor.validate('preview.one', { id: '42' });
+
+    expect(result.valid).toBe(true);
+    expect(result.predictedChanges).toBeDefined();
+    expect(result.predictedChanges).toHaveLength(1);
+    const change = (result.predictedChanges as Change[])[0]!;
+    expect(change.action).toBe('send');
+    expect(change.target).toBe('smtp:user-42');
+    expect(change.summary).toBe('Send confirmation email');
+    expect(change.before).toBeUndefined();
+    expect(change.after).toBeUndefined();
+  });
+
+  it('preview() returning multiple Changes preserves order and before/after', async () => {
+    const mod: Module = {
+      inputSchema,
+      outputSchema,
+      description: 'Preview multiple changes',
+      execute: () => ({ ok: true }),
+      preview: async (): Promise<PreviewResult> => ({
+        changes: [
+          {
+            action: 'delete',
+            target: 'users.42',
+            summary: 'Permanently delete user 42',
+            before: { id: 42, email: 'a@example.com', tier: 'gold' },
+          },
+          {
+            action: 'write',
+            target: 'audit_log',
+            summary: 'Append audit row for user deletion',
+            after: { event: 'user.deleted', user_id: 42 },
+          },
+          {
+            action: 'send',
+            target: 'smtp:a@example.com',
+            summary: 'Send goodbye email',
+          },
+        ],
+      }),
+    };
+    const executor = buildExecutor('preview.many', mod);
+    const result = await executor.validate('preview.many', { id: '42' });
+
+    expect(result.valid).toBe(true);
+    expect(result.predictedChanges).toBeDefined();
+    const changes = result.predictedChanges as Change[];
+    expect(changes).toHaveLength(3);
+
+    expect(changes[0]!.action).toBe('delete');
+    expect(changes[0]!.before).toEqual({
+      id: 42,
+      email: 'a@example.com',
+      tier: 'gold',
+    });
+    expect(changes[0]!.after).toBeUndefined();
+
+    expect(changes[1]!.action).toBe('write');
+    expect(changes[1]!.after).toEqual({ event: 'user.deleted', user_id: 42 });
+    expect(changes[1]!.before).toBeUndefined();
+
+    expect(changes[2]!.action).toBe('send');
+    expect(changes[2]!.summary).toBe('Send goodbye email');
+  });
+
+  it('preview() throwing synchronously surfaces a warning but does not fail validation', async () => {
+    const mod: Module = {
+      inputSchema,
+      outputSchema,
+      description: 'Preview that throws sync',
+      execute: () => ({ ok: true }),
+      preview: (): PreviewResult => {
+        throw new Error('preview-sync-boom');
+      },
+    };
+    const executor = buildExecutor('preview.sync.throw', mod);
+    const result = await executor.validate('preview.sync.throw', { id: 'x' });
+
+    // Validation must NOT fail.
+    expect(result.valid).toBe(true);
+    expect(result.errors).toEqual([]);
+    // No changes recorded.
+    expect(result.predictedChanges).toBeUndefined();
+    // Warning surfaces via the dedicated check.
+    const previewCheck = result.checks.find(
+      (c: PreflightCheckResult) => c.check === 'module_preview',
+    );
+    expect(previewCheck).toBeDefined();
+    expect(previewCheck!.passed).toBe(true);
+    expect(previewCheck!.warnings).toBeDefined();
+    expect(previewCheck!.warnings!.some((w) => w.includes('preview-sync-boom'))).toBe(true);
+  });
+
+  it('preview() rejecting asynchronously surfaces a warning but does not fail validation', async () => {
+    const mod: Module = {
+      inputSchema,
+      outputSchema,
+      description: 'Preview that rejects async',
+      execute: () => ({ ok: true }),
+      preview: async (): Promise<PreviewResult | null> => {
+        throw new Error('preview-async-boom');
+      },
+    };
+    const executor = buildExecutor('preview.async.throw', mod);
+    const result = await executor.validate('preview.async.throw', { id: 'x' });
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toEqual([]);
+    expect(result.predictedChanges).toBeUndefined();
+    const previewCheck = result.checks.find(
+      (c: PreflightCheckResult) => c.check === 'module_preview',
+    );
+    expect(previewCheck).toBeDefined();
+    expect(previewCheck!.passed).toBe(true);
+    expect(previewCheck!.warnings!.some((w) => w.includes('preview-async-boom'))).toBe(true);
+  });
+
+  it('preview() supports `x-*` extension fields on Change records', async () => {
+    const mod: Module = {
+      inputSchema,
+      outputSchema,
+      description: 'Preview with x-* extension',
+      execute: () => ({ ok: true }),
+      preview: (): PreviewResult => ({
+        changes: [
+          {
+            action: 'charge',
+            target: 'stripe:charge:ch_abc',
+            summary: 'Charge $9.99',
+            'x-confidence': 0.95,
+          },
+        ],
+      }),
+    };
+    const executor = buildExecutor('preview.ext', mod);
+    const result = await executor.validate('preview.ext', { id: 'x' });
+
+    expect(result.valid).toBe(true);
+    const changes = result.predictedChanges as Change[];
+    expect(changes).toHaveLength(1);
+    expect(changes[0]!['x-confidence']).toBe(0.95);
+  });
+});


### PR DESCRIPTION
Closes #27

**Implements `Module.preview()` per upstream apcore RFC `docs/spec/rfc-preview-method.md` (currently `Draft / RFC`). Maintainer should decide whether to merge before or after upstream accept.**

This is a speculative implementation ahead of formal RFC acceptance into `PROTOCOL_SPEC.md`. Field names (`predictedChanges`, `Change.action` / `target` / `summary` / `before` / `after`) and semantics (preview-throws-as-advisory-warning) may shift if the RFC is amended before acceptance.

## Cross-repo coordination

The companion Rust prerequisite `apcore-rust#24` (mark spec-derived public structs `#[non_exhaustive]`) is **not a blocker for this TypeScript PR**. TypeScript `interface { foo?: T }` is forward-compatible by construction — adding `predictedChanges?: Change[]` to `PreflightResult` cannot break downstream consumers that construct or destructure the interface today. The Rust hygiene work is entirely scoped to that SDK.

## Summary

### Types added (`src/module.ts`)

- `interface PreviewResult { changes: Change[] }`
- `interface Change { action: string; target: string; summary: string; before?: unknown; after?: unknown; [key: ` + "`x-${string}`" + `]: unknown }`
- `Module.preview?(inputs, ctx): PreviewResult | null | Promise<PreviewResult | null>` — optional, mirrors existing `preflight?` / `stream?` pattern.
- `PreflightResult.predictedChanges?: Change[]` — populated by `Executor.validate()` when the resolved module implements `preview()` and the result is non-null.
- TypeBox schemas `TPreviewResult` and `TChange` — exported alongside the types in `src/module.ts` and re-exported from the package root in `src/index.ts`.

### `Executor.validate()` changes (`src/executor.ts`)

After the existing module-level `preflight()` block, `validate()` now:

1. Detects `typeof module.preview === 'function'`.
2. Invokes it with `(inputs, context)`; awaits the return value if it's a Promise.
3. If the result is non-null and `result.changes` is a non-empty array, sets `predictedChanges = result.changes` on the returned `PreflightResult` and records a passing `module_preview` check.
4. If `preview()` throws or rejects, surfaces the error message as a warning on the `module_preview` check (passed = true) and does **not** fail validation. Mirrors existing `preflight()` semantics (RFC Open Question 1: "match preflight() for ergonomic parity").

`createPreflightResult()` gains an optional third `predictedChanges` parameter; absence is omitted from the result object so existing snapshots / equality checks for modules without preview() are unchanged.

## Tests

7 new test cases in `tests/test-module-preview.test.ts`:

- Module without `preview()` → `predictedChanges` absent, no `module_preview` check.
- `preview()` returning `null` → `predictedChanges` absent, `module_preview` check passes.
- `preview()` returning a single `Change` (required fields only) → exact change present in `predictedChanges`, `before` / `after` undefined.
- `preview()` returning multiple `Change`s with mixed `before` / `after` → all present in order, snapshots intact.
- `preview()` throwing synchronously → validation succeeds, warning surfaces on `module_preview`.
- `preview()` rejecting asynchronously (rejected Promise) → validation succeeds, warning surfaces on `module_preview`.
- `preview()` returning a `Change` with `x-*` extension fields → extension preserved in `predictedChanges`.

## Test plan

- [x] `pnpm test` — full suite passes (2632 tests).
- [x] `pnpm run typecheck` — no errors.
- [x] `pnpm run lint` — no new lint errors in changed files (pre-existing repo-wide warnings unrelated).
- [ ] Maintainer decision on merge timing relative to upstream RFC acceptance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)