### PR TITLE
chore: drop multiClassEnabled arg from Registry.discoverMultiClass [#28]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [Unreleased]
+
+### Changed
+
+- **Issue #28 — `Registry.discoverMultiClass` signature cleanup (apcore decision-log D-06).** The 4th `multiClassEnabled` argument is dropped from the canonical method surface; the method is now `discoverMultiClass(filePath, classes, extensionsRoot?)`. Per-class opt-in via the new `ClassDescriptor.multiClass?: boolean` field is the sole source of truth — when at least one qualifying class sets `multiClass: true`, the discovery routine derives a distinct module ID per class; otherwise whole-file mode applies. Mirrors the upstream apcore doc-side cleanup in commit [`973410b`](https://github.com/aiperceivable/apcore/commit/973410b) which removed the dead global `extensions.multi_class_discovery` config toggle.
+  - **DEPRECATION:** the legacy 4-arg overload `discoverMultiClass(filePath, classes, extensionsRoot, multiClassEnabled)` is retained for backward compatibility and emits a one-shot `console.warn` deprecation notice on first use. The `multiClassEnabled` argument is **functionally inert** — the per-class `multiClass` field is read regardless of what is passed. The 4-arg overload will be removed in **v0.22.0**. Migration: drop the boolean and mark each `ClassDescriptor` you want as a separate module with `multiClass: true`.
+  - The free function `discoverMultiClass(...)` re-exported from `apcore-js/registry` keeps its existing 4-arg shape for internal callers and is unchanged.
+
 ## [0.20.0] - 2026-05-05
 
 ### Added

--- a/src/registry/multi-class.ts
+++ b/src/registry/multi-class.ts
@@ -13,6 +13,20 @@ const MAX_MODULE_ID_LEN = 192;
 export interface ClassDescriptor {
   readonly name: string;
   readonly implementsModule: boolean;
+  /**
+   * Per-class opt-in marker for multi-class mode (apcore decision-log D-06).
+   *
+   * When at least one qualifying class in the file has `multiClass: true`,
+   * the discovery routine derives a distinct module ID per class. When no
+   * qualifying class sets the flag, whole-file mode is used and the bare
+   * base_id is returned.
+   *
+   * This field replaces the previous global `multiClassEnabled` parameter
+   * on `Registry.discoverMultiClass`. See apcore commit 973410b for the
+   * upstream cleanup that removed the dead `extensions.multi_class_discovery`
+   * config toggle.
+   */
+  readonly multiClass?: boolean;
 }
 
 export interface MultiClassEntry {

--- a/src/registry/registry.ts
+++ b/src/registry/registry.ts
@@ -64,6 +64,39 @@ async function lazyScanMultiRoot(
 }
 
 /**
+ * One-shot deprecation flag for the legacy 4-arg
+ * `Registry.discoverMultiClass(filePath, classes, extensionsRoot, multiClassEnabled)`
+ * call shape. Cleared per process so the warning fires at most once even
+ * across many invocations from the same caller. See apcore decision-log
+ * D-06 (apcore commit 973410b).
+ *
+ * @internal exported for tests so they can reset between cases.
+ */
+let _multiClassEnabledDeprecationWarned = false;
+
+/**
+ * Reset the one-shot deprecation flag for the legacy 4-arg
+ * `Registry.discoverMultiClass` overload. Test-only — production callers
+ * never need this.
+ *
+ * @internal
+ */
+export function _resetMultiClassEnabledDeprecationWarned(): void {
+  _multiClassEnabledDeprecationWarned = false;
+}
+
+function warnMultiClassEnabledDeprecated(): void {
+  if (_multiClassEnabledDeprecationWarned) return;
+  _multiClassEnabledDeprecationWarned = true;
+  console.warn(
+    '[apcore:registry] DEPRECATION: the `multiClassEnabled` argument to ' +
+    '`Registry.discoverMultiClass()` is deprecated and ignored under apcore ' +
+    'decision-log D-06. Mark each `ClassDescriptor` with `multiClass: true` ' +
+    'instead. The 4-arg overload will be removed in v0.22.0.',
+  );
+}
+
+/**
  * Standard registry event names.
  */
 export const REGISTRY_EVENTS = Object.freeze({
@@ -1074,14 +1107,50 @@ export class Registry {
    * and the Rust trait method. Internally delegates to the free function
    * {@link discoverMultiClass} (re-exported as `_discoverMultiClass` for
    * scanner internals), so behaviour is identical.
+   *
+   * **apcore decision-log D-06**: the per-class `ClassDescriptor.multiClass`
+   * flag is the sole opt-in mechanism for multi-class discovery. When any
+   * qualifying class sets `multiClass: true`, the discovery routine derives
+   * a distinct module ID per class; otherwise whole-file mode is used.
+   *
+   * @param filePath - Source file path (relative to project root).
+   * @param classes - Class descriptors; each may carry `multiClass: true`
+   *   to opt into per-class module ID derivation.
+   * @param extensionsRoot - Extensions root directory (defaults to
+   *   `'extensions'`).
+   *
+   * **Deprecated 4-arg overload**: passing a `multiClassEnabled` boolean as
+   * the fourth argument is retained for backward compatibility through one
+   * minor release and will be removed in v0.22.0. The argument is now
+   * functionally inert — the per-class `multiClass` field is the source of
+   * truth. A one-shot deprecation notice is emitted on first use.
    */
   discoverMultiClass(
     filePath: string,
     classes: readonly import('./multi-class.js').ClassDescriptor[],
+    extensionsRoot?: string,
+  ): import('./multi-class.js').MultiClassEntry[];
+  /** @deprecated Pass `multiClass: true` on each `ClassDescriptor` instead. The `multiClassEnabled` argument will be removed in v0.22.0. */
+  discoverMultiClass(
+    filePath: string,
+    classes: readonly import('./multi-class.js').ClassDescriptor[],
+    extensionsRoot: string,
+    multiClassEnabled: boolean,
+  ): import('./multi-class.js').MultiClassEntry[];
+  discoverMultiClass(
+    filePath: string,
+    classes: readonly import('./multi-class.js').ClassDescriptor[],
     extensionsRoot: string = 'extensions',
-    multiClassEnabled: boolean = false,
+    multiClassEnabled?: boolean,
   ): import('./multi-class.js').MultiClassEntry[] {
-    return _discoverMultiClass(filePath, classes, extensionsRoot, multiClassEnabled);
+    if (multiClassEnabled !== undefined) {
+      warnMultiClassEnabledDeprecated();
+      // The argument is functionally inert under D-06: the per-class
+      // `multiClass` field is the source of truth. We intentionally ignore
+      // `multiClassEnabled` and recompute from the descriptors below.
+    }
+    const enabled = classes.some((c) => c.implementsModule && c.multiClass === true);
+    return _discoverMultiClass(filePath, classes, extensionsRoot, enabled);
   }
 
   /**

--- a/tests/registry/test-discover-multi-class-method.test.ts
+++ b/tests/registry/test-discover-multi-class-method.test.ts
@@ -5,8 +5,11 @@
  * The free function is preserved as `_discoverMultiClass` (internal).
  */
 
-import { describe, it, expect } from 'vitest';
-import { Registry } from '../../src/registry/registry.js';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  Registry,
+  _resetMultiClassEnabledDeprecationWarned,
+} from '../../src/registry/registry.js';
 import { _discoverMultiClass, discoverMultiClass, classNameToSegment } from '../../src/registry/multi-class.js';
 import { IdTooLongError, InvalidSegmentError, ModuleIdConflictError } from '../../src/errors.js';
 
@@ -16,32 +19,149 @@ describe('Registry.discoverMultiClass', () => {
     expect(typeof (registry as unknown as { discoverMultiClass: unknown }).discoverMultiClass).toBe('function');
   });
 
-  it('returns the same result as the free function', () => {
+  it('returns the same result as the free function (per-class multiClass marker)', () => {
     const registry = new Registry();
     const filePath = 'extensions/email/sender.ts';
     const classes = [
-      { name: 'EmailSender', implementsModule: true },
-      { name: 'EmailFormatter', implementsModule: true },
+      { name: 'EmailSender', implementsModule: true, multiClass: true },
+      { name: 'EmailFormatter', implementsModule: true, multiClass: true },
     ];
 
     const free = _discoverMultiClass(filePath, classes, 'extensions', true);
-    const method = registry.discoverMultiClass(filePath, classes, 'extensions', true);
+    // Canonical 3-arg call shape (D-06): no multiClassEnabled.
+    const method = registry.discoverMultiClass(filePath, classes, 'extensions');
     expect(method).toEqual(free);
+  });
+
+  it('3-arg form: per-class `multiClass: true` enables multi-class derivation', () => {
+    const registry = new Registry();
+    const result = registry.discoverMultiClass(
+      'extensions/math/math_ops.ts',
+      [
+        { name: 'Addition', implementsModule: true, multiClass: true },
+        { name: 'Subtraction', implementsModule: true, multiClass: true },
+      ],
+      'extensions',
+    );
+    expect(result).toEqual([
+      { moduleId: 'math.math_ops.addition', className: 'Addition' },
+      { moduleId: 'math.math_ops.subtraction', className: 'Subtraction' },
+    ]);
+  });
+
+  it('3-arg form: no class with `multiClass` falls back to whole-file mode', () => {
+    const registry = new Registry();
+    const result = registry.discoverMultiClass(
+      'extensions/email/sender.ts',
+      [
+        { name: 'A', implementsModule: true },
+        { name: 'B', implementsModule: true },
+      ],
+      'extensions',
+    );
+    expect(result).toEqual([{ moduleId: 'email.sender', className: 'A' }]);
+  });
+
+  it('3-arg form: extensionsRoot is optional and defaults to "extensions"', () => {
+    const registry = new Registry();
+    const result = registry.discoverMultiClass(
+      'extensions/email/sender.ts',
+      [{ name: 'Sender', implementsModule: true, multiClass: true }],
+    );
+    expect(result).toEqual([{ moduleId: 'email.sender', className: 'Sender' }]);
   });
 
   it('preserves single-class identity guarantee', () => {
     const registry = new Registry();
     const result = registry.discoverMultiClass(
       'extensions/email/sender.ts',
-      [{ name: 'Sender', implementsModule: true }],
+      [{ name: 'Sender', implementsModule: true, multiClass: true }],
       'extensions',
-      true,
     );
     expect(result).toEqual([{ moduleId: 'email.sender', className: 'Sender' }]);
   });
 
   it('public free function is still exported for backwards compatibility', () => {
     expect(typeof discoverMultiClass).toBe('function');
+  });
+});
+
+describe('Registry.discoverMultiClass — deprecated 4-arg overload (D-06)', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    _resetMultiClassEnabledDeprecationWarned();
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+    _resetMultiClassEnabledDeprecationWarned();
+  });
+
+  it('still accepts the 4-arg call shape and emits a deprecation warning', () => {
+    const registry = new Registry();
+    const result = registry.discoverMultiClass(
+      'extensions/email/sender.ts',
+      [{ name: 'Sender', implementsModule: true, multiClass: true }],
+      'extensions',
+      true,
+    );
+    expect(result).toEqual([{ moduleId: 'email.sender', className: 'Sender' }]);
+    const deprecationWarn = warnSpy.mock.calls.find((call) =>
+      typeof call[0] === 'string' && call[0].includes('DEPRECATION') && call[0].includes('multiClassEnabled'),
+    );
+    expect(deprecationWarn).toBeDefined();
+  });
+
+  it('deprecation warning fires only once per process', () => {
+    const registry = new Registry();
+    const args = [
+      'extensions/email/sender.ts',
+      [{ name: 'Sender', implementsModule: true, multiClass: true }],
+      'extensions',
+      true,
+    ] as const;
+    registry.discoverMultiClass(...args);
+    registry.discoverMultiClass(...args);
+    registry.discoverMultiClass(...args);
+
+    const deprecationWarnings = warnSpy.mock.calls.filter((call) =>
+      typeof call[0] === 'string' && call[0].includes('DEPRECATION') && call[0].includes('multiClassEnabled'),
+    );
+    expect(deprecationWarnings).toHaveLength(1);
+  });
+
+  it('the 4th `multiClassEnabled` argument is functionally inert — the per-class marker is the source of truth', () => {
+    const registry = new Registry();
+
+    // multiClassEnabled=false but classes are marked multiClass:true → still multi-class mode.
+    const enabledViaMarker = registry.discoverMultiClass(
+      'extensions/math/math_ops.ts',
+      [
+        { name: 'Addition', implementsModule: true, multiClass: true },
+        { name: 'Subtraction', implementsModule: true, multiClass: true },
+      ],
+      'extensions',
+      false,
+    );
+    expect(enabledViaMarker).toEqual([
+      { moduleId: 'math.math_ops.addition', className: 'Addition' },
+      { moduleId: 'math.math_ops.subtraction', className: 'Subtraction' },
+    ]);
+
+    // multiClassEnabled=true but no class is marked → whole-file mode wins.
+    _resetMultiClassEnabledDeprecationWarned();
+    const disabledByMarker = registry.discoverMultiClass(
+      'extensions/email/sender.ts',
+      [
+        { name: 'A', implementsModule: true },
+        { name: 'B', implementsModule: true },
+      ],
+      'extensions',
+      true,
+    );
+    expect(disabledByMarker).toEqual([{ moduleId: 'email.sender', className: 'A' }]);
   });
 });
 


### PR DESCRIPTION
Closes #28

## Summary

Per apcore decision-log entry **D-06** (Recommendation B: per-class decorator only), the global `extensions.multi_class_discovery` toggle is dead documentation, and the per-class marker is the only meaningful opt-in. The doc-side cleanup landed upstream at apcore commit [`973410b`](https://github.com/aiperceivable/apcore/commit/973410b). This PR aligns the TypeScript SDK surface.

### Signature change

```diff
- Registry.discoverMultiClass(filePath, classes, extensionsRoot, multiClassEnabled)
+ Registry.discoverMultiClass(filePath, classes, extensionsRoot?)
```

### Per-class marker source — Option A (`ClassDescriptor.multiClass`)

The repo had no existing `@multiClass()` decorator and no `reflect-metadata` dependency. Per the issue, when both options could work, prefer Option A. Added an optional `multiClass?: boolean` field to `ClassDescriptor`. When at least one qualifying class sets `multiClass: true`, the discovery routine derives a distinct module ID per class; otherwise whole-file mode applies.

### Backward compatibility

- The 4-arg overload `discoverMultiClass(filePath, classes, extensionsRoot, multiClassEnabled)` is retained.
- It emits a **one-shot** `console.warn` deprecation notice (gated by a module-level boolean) on first use per process.
- The `multiClassEnabled` argument is **functionally inert** — the per-class `multiClass` field is the source of truth regardless of what is passed.
- **Removal target: v0.22.0** (noted in the deprecation message and CHANGELOG).
- The free function `discoverMultiClass(...)` re-exported from `apcore-js/registry` keeps its existing 4-arg shape (internal).

## Files changed

- `src/registry/multi-class.ts` — added `ClassDescriptor.multiClass?: boolean`
- `src/registry/registry.ts` — overload set, deprecation gate, `_resetMultiClassEnabledDeprecationWarned` test hook
- `tests/registry/test-discover-multi-class-method.test.ts` — updated existing tests to canonical 3-arg form, added a deprecation suite
- `CHANGELOG.md` — `[Unreleased] ### Changed` entry with v0.22.0 removal target

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm test` — 2631 passed / 2 skipped (107 test files)
- [x] Targeted suite for this change: 18/18 pass (canonical 3-arg, deprecation warn, one-shot gate, functionally-inert verification)

## Follow-up note

Once landed, follow-up needed in the apcore repo to refresh the TypeScript signature in `docs/features/multi-module-discovery.md` (Inputs section, table at line 242, code example at line 290) — currently still shows the 4-arg form to match the SDK's actual current API.