### PR TITLE
feat(errors): add SysModulesDisabledError typed error class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [Unreleased]
+## [0.22.0] - 2026-05-22
 
 ### Added
 
@@ -27,9 +27,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - **`emitWithLegacy()` helper and legacy event aliases ([apcore#36](https://github.com/aiperceivable/apcore/issues/36)).** Per spec v0.22.0 finalization, the legacy event names `module_registered`, `module_unregistered`, `error_threshold_exceeded`, and `latency_threshold_exceeded` are no longer emitted alongside their canonical `apcore.<subsystem>.<event>` counterparts. The `emitWithLegacy` helper has been deleted from `src/events/emitter.ts` and the public surface. Subscribers MUST listen on the canonical names (`apcore.registry.module_registered`, `apcore.health.error_threshold_exceeded`, etc.). Closes finding A-D-EVT-002.
-
-
-## [0.22.0] - 2026-05-20
 
 ### Added
 

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -155,6 +155,7 @@ export {
   CircuitBreakerOpenError,
   ModuleReloadConflictError,
   SysModuleRegistrationError,
+  SysModulesDisabledError,
   ErrorCodes,
 } from '../errors.js';
 export type { ErrorCode, ErrorOptions } from '../errors.js';

--- a/src/client.ts
+++ b/src/client.ts
@@ -6,6 +6,7 @@ import type { TSchema } from '@sinclair/typebox';
 import type { Config } from './config.js';
 import type { Context } from './context.js';
 import { FunctionModule, module as createModule } from './decorator.js';
+import { SysModulesDisabledError } from './errors.js';
 import type { ApCoreEvent, EventSubscriber } from './events/emitter.js';
 import { EventEmitter } from './events/emitter.js';
 import { Executor } from './executor.js';
@@ -236,7 +237,7 @@ export class APCore {
   ): EventSubscriber {
     const emitter = this.events;
     if (!emitter) {
-      throw new Error(
+      throw new SysModulesDisabledError(
         'Events are not enabled. Set sys_modules.enabled=true and '
         + 'sys_modules.events.enabled=true in config.',
       );
@@ -254,11 +255,14 @@ export class APCore {
 
   /**
    * Unsubscribe a previously registered event subscriber.
+   *
+   * @throws {SysModulesDisabledError} If events are not enabled
+   *   (code `SYS_MODULES_DISABLED`).
    */
   off(subscriber: EventSubscriber): void {
     const emitter = this.events;
     if (!emitter) {
-      throw new Error(
+      throw new SysModulesDisabledError(
         'Events are not enabled. Set sys_modules.enabled=true and '
         + 'sys_modules.events.enabled=true in config.',
       );
@@ -294,7 +298,7 @@ export class APCore {
 
   private _requireSysModules(method: string): void {
     if (!this._sysModulesContext || Object.keys(this._sysModulesContext).length === 0) {
-      throw new Error(
+      throw new SysModulesDisabledError(
         `Cannot call ${method}(): sys_modules must be enabled in config.`,
       );
     }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1222,6 +1222,34 @@ export class SysModuleRegistrationError extends ModuleError {
   }
 }
 
+/**
+ * Raised when an APCore client method requires sys_modules to be enabled.
+ *
+ * Cross-language equivalent of Rust's `ModuleError(code=SysModulesDisabled)`
+ * and Python's `SysModulesDisabledError`. Replaces bare `Error` in
+ * `APCore.on/off/disable/enable` so callers can dispatch on
+ * `error.code === 'SYS_MODULES_DISABLED'` instead of catching generic
+ * `Error`.
+ */
+export class SysModulesDisabledError extends ModuleError {
+  static override readonly DEFAULT_RETRYABLE: boolean | null = false;
+
+  constructor(message: string, options?: ErrorOptions) {
+    super(
+      'SYS_MODULES_DISABLED',
+      message,
+      undefined,
+      options?.cause,
+      options?.traceId,
+      options?.retryable,
+      options?.aiGuidance,
+      options?.userFixable,
+      options?.suggestion,
+    );
+    this.name = 'SysModulesDisabledError';
+  }
+}
+
 export class DuplicateModuleIdError extends ModuleError {
   static override readonly DEFAULT_RETRYABLE: boolean | null = false;
 
@@ -1336,6 +1364,7 @@ export const ErrorCodes = Object.freeze({
   CIRCUIT_BREAKER_OPEN: 'CIRCUIT_BREAKER_OPEN',
   MODULE_RELOAD_CONFLICT: 'MODULE_RELOAD_CONFLICT',
   SYS_MODULE_REGISTRATION_FAILED: 'SYS_MODULE_REGISTRATION_FAILED',
+  SYS_MODULES_DISABLED: 'SYS_MODULES_DISABLED',
   DUPLICATE_MODULE_ID: 'DUPLICATE_MODULE_ID',
   STREAMING_INTERFACE_MISMATCH: 'STREAMING_INTERFACE_MISMATCH',
 } as const);

--- a/src/index.ts
+++ b/src/index.ts
@@ -155,6 +155,7 @@ export {
   CircuitBreakerOpenError,
   ModuleReloadConflictError,
   SysModuleRegistrationError,
+  SysModulesDisabledError,
   StreamingInterfaceError,
   DuplicateModuleIdError,
   ErrorCodes,


### PR DESCRIPTION
## Summary

Replaces bare `throw new Error(...)` raises in `APCore.on` / `off` / `_requireSysModules` with a typed `SysModulesDisabledError` (code `SYS_MODULES_DISABLED`, `DEFAULT_RETRYABLE=false`).

Callers can now dispatch on `err instanceof SysModulesDisabledError` or `err.code === 'SYS_MODULES_DISABLED'` instead of catching the generic `Error` base.

Cross-language equivalent of Rust's `ErrorCode::SysModulesDisabled` and the parallel [apcore-python#29](https://github.com/aiperceivable/apcore-python/pull/29). Exported from both Node entry (`src/index.ts`) and browser entry (`src/browser/index.ts`).

## Test plan

- [x] `pnpm run build` (tsc) → clean
- [x] `pnpm test --run` → **2721 passed / 0 failed / 2 skipped** (117 files)
- [x] Both Node and browser entries export the new class
- [x] `DEFAULT_RETRYABLE=false` — sys_modules state is config-time, not retry-fixable